### PR TITLE
Branch with configurable cgroups and log levels applied

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -109,10 +109,6 @@ var JailerConfigValidationHandler = Handler{
 			return fmt.Errorf("UID must be specified when using jailer mode")
 		}
 
-		if m.Cfg.JailerCfg.NumaNode == nil {
-			return fmt.Errorf("ID must be specified when using jailer mode")
-		}
-
 		return nil
 	},
 }

--- a/jailer.go
+++ b/jailer.go
@@ -149,7 +149,7 @@ func (b JailerCommandBuilder) Args() []string {
 
 	if b.node != nil {
 		if cpulist := getNumaCpuset(*b.node); len(cpulist) > 0 {
-			args = append(args, "--cgroup", fmt.Sprintf("cpuset.mems=%d", b.node))
+			args = append(args, "--cgroup", fmt.Sprintf("cpuset.mems=%d", *b.node))
 			args = append(args, "--cgroup", fmt.Sprintf("cpuset.cpus=%s", cpulist))
 		}
 	}

--- a/jailer.go
+++ b/jailer.go
@@ -339,6 +339,10 @@ func jail(ctx context.Context, m *Machine, cfg *Config) error {
 	fcArgs := seccompArgs(cfg)
 	fcArgs = append(fcArgs, "--api-sock", machineSocketPath)
 
+	if cfg.LogLevel != "" {
+		fcArgs = append(fcArgs, "--level", cfg.LogLevel)
+	}
+
 	builder := NewJailerCommandBuilder().
 		WithID(cfg.JailerCfg.ID).
 		WithUID(*cfg.JailerCfg.UID).

--- a/jailer.go
+++ b/jailer.go
@@ -86,6 +86,7 @@ type JailerConfig struct {
 	// CgroupVersion is the version of the cgroup filesystem to use.
 	CgroupVersion string
 
+	// CgroupArgs are the cgroup arguments to pass to the jailer.
 	CgroupArgs []string
 
 	// Stdout specifies the IO writer for STDOUT to use when spawning the jailer.
@@ -221,6 +222,8 @@ func (b JailerCommandBuilder) WithNumaNode(node int) JailerCommandBuilder {
 	return b
 }
 
+// WithCgroupArgs will set the specified cgroup args to the builder. This
+// represents the cgroup settings that the process will get assigned.
 func (b JailerCommandBuilder) WithCgroupArgs(cgroupArgs ...string) JailerCommandBuilder {
 	b.cgroupArgs = cgroupArgs
 	return b

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -34,7 +34,6 @@ func TestJailerBuilder(t *testing.T) {
 				ID:             "my-test-id",
 				UID:            Int(123),
 				GID:            Int(100),
-				NumaNode:       Int(0),
 				ChrootStrategy: NewNaiveChrootStrategy("kernel-image-path"),
 				ExecFile:       "/path/to/firecracker",
 			},
@@ -48,10 +47,6 @@ func TestJailerBuilder(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
-				"--cgroup",
-				"cpuset.mems=0",
-				"--cgroup",
-				fmt.Sprintf("cpuset.cpus=%s", getNumaCpuset(0)),
 			},
 			expectedSockPath: filepath.Join(
 				defaultJailerPath,
@@ -67,7 +62,6 @@ func TestJailerBuilder(t *testing.T) {
 				ID:             "my-test-id",
 				UID:            Int(123),
 				GID:            Int(100),
-				NumaNode:       Int(0),
 				ChrootStrategy: NewNaiveChrootStrategy("kernel-image-path"),
 				ExecFile:       "/path/to/firecracker",
 				JailerBinary:   "imprisoner",
@@ -82,10 +76,6 @@ func TestJailerBuilder(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
-				"--cgroup",
-				"cpuset.mems=0",
-				"--cgroup",
-				fmt.Sprintf("cpuset.cpus=%s", getNumaCpuset(0)),
 			},
 			expectedSockPath: filepath.Join(
 				defaultJailerPath,
@@ -145,9 +135,12 @@ func TestJailerBuilder(t *testing.T) {
 				WithID(c.jailerCfg.ID).
 				WithUID(IntValue(c.jailerCfg.UID)).
 				WithGID(IntValue(c.jailerCfg.GID)).
-				WithNumaNode(IntValue(c.jailerCfg.NumaNode)).
 				WithCgroupVersion(c.jailerCfg.CgroupVersion).
 				WithExecFile(c.jailerCfg.ExecFile)
+
+			if c.jailerCfg.NumaNode != nil {
+				b = b.WithNumaNode(IntValue(c.jailerCfg.NumaNode))
+			}
 
 			if len(c.jailerCfg.JailerBinary) > 0 {
 				b = b.WithBin(c.jailerCfg.JailerBinary)
@@ -188,7 +181,6 @@ func TestJail(t *testing.T) {
 				ID:             "my-test-id",
 				UID:            Int(123),
 				GID:            Int(100),
-				NumaNode:       Int(0),
 				ChrootStrategy: NewNaiveChrootStrategy("kernel-image-path"),
 				ExecFile:       "/path/to/firecracker",
 			},
@@ -202,10 +194,6 @@ func TestJail(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
-				"--cgroup",
-				"cpuset.mems=0",
-				"--cgroup",
-				fmt.Sprintf("cpuset.cpus=%s", getNumaCpuset(0)),
 				"--",
 				"--no-seccomp",
 				"--api-sock",
@@ -225,7 +213,6 @@ func TestJail(t *testing.T) {
 				ID:             "my-test-id",
 				UID:            Int(123),
 				GID:            Int(100),
-				NumaNode:       Int(0),
 				ChrootStrategy: NewNaiveChrootStrategy("kernel-image-path"),
 				ExecFile:       "/path/to/firecracker",
 				JailerBinary:   "imprisoner",
@@ -240,10 +227,6 @@ func TestJail(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
-				"--cgroup",
-				"cpuset.mems=0",
-				"--cgroup",
-				fmt.Sprintf("cpuset.cpus=%s", getNumaCpuset(0)),
 				"--",
 				"--no-seccomp",
 				"--api-sock",

--- a/jailer_test.go
+++ b/jailer_test.go
@@ -98,6 +98,7 @@ func TestJailerBuilder(t *testing.T) {
 				ChrootBaseDir:  "/tmp",
 				JailerBinary:   "/path/to/the/jailer",
 				CgroupVersion:  "2",
+				CgroupArgs:     []string{"cpu.weight=200"},
 			},
 			expectedArgs: []string{
 				"/path/to/the/jailer",
@@ -109,6 +110,8 @@ func TestJailerBuilder(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
+				"--cgroup",
+				"cpu.weight=200",
 				"--cgroup",
 				"cpuset.mems=0",
 				"--cgroup",
@@ -140,6 +143,10 @@ func TestJailerBuilder(t *testing.T) {
 
 			if c.jailerCfg.NumaNode != nil {
 				b = b.WithNumaNode(IntValue(c.jailerCfg.NumaNode))
+			}
+
+			if len(c.jailerCfg.CgroupArgs) > 0 {
+				b = b.WithCgroupArgs(c.jailerCfg.CgroupArgs...)
 			}
 
 			if len(c.jailerCfg.JailerBinary) > 0 {
@@ -253,6 +260,7 @@ func TestJail(t *testing.T) {
 				ChrootBaseDir:  "/tmp",
 				JailerBinary:   "/path/to/the/jailer",
 				CgroupVersion:  "2",
+				CgroupArgs:     []string{"cpu.weight=200"},
 			},
 			expectedArgs: []string{
 				"/path/to/the/jailer",
@@ -264,6 +272,8 @@ func TestJail(t *testing.T) {
 				"100",
 				"--exec-file",
 				"/path/to/firecracker",
+				"--cgroup",
+				"cpu.weight=200",
 				"--cgroup",
 				"cpuset.mems=0",
 				"--cgroup",


### PR DESCRIPTION
This branch is generated from the latest `main` from `firecracker-go-sdk`, and then the following commands were executed:

```sh
$ git checkout -b cgroups-and-log-level
$ git merge jailer-configurable-cgroups
$ git merge jailer-log-level
$ git push origin cgroups-and-log-level
```

* https://github.com/firecracker-microvm/firecracker-go-sdk/pull/574
* https://github.com/firecracker-microvm/firecracker-go-sdk/pull/493